### PR TITLE
Release/1.4.0 - Ensure generate works with Amazon Linux 2023

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "aws_region" {

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -105,13 +105,7 @@ class Uploader:
         self.processing_type = processing_type
         self.dataset = dataset
         self.logger = logger
-        if venue == "ops":
-            self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
-        else:
-            if dataset == "viirs":
-                self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
-            else:
-                self.cumulus_topic = f"podaac-{venue}-cumulus-throttled-provider-input-sns"
+        self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
         self.cross_account = self.get_cross_account_id(prefix)
         self.processed = []
         self.provenance = []


### PR DESCRIPTION
## [0.1.4]

This uploader release is part of this PR: https://github.com/podaac/generate/pull/21

### Description

Update to use the same SNS topic for CNM message publication across all 3 datasets (MODIS A/T and VIIRS).

### Overview of work done

- Updated to use single SNS topic: `podaac-{venue}-cumulus-provider-input-sns`

### Overview of verification done

Small change, no unit tests required.

### Overview of integration done

Deployed to services SIT and services UAT; tested in UAT alongside AWS Batch compute environment testing.

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_