### PR TITLE
Release/0.1.7

### DIFF
--- a/terraform/generate-uploader.tf
+++ b/terraform/generate-uploader.tf
@@ -29,8 +29,8 @@ resource "aws_batch_job_definition" "generate_batch_jd_uploader" {
         }
     ],
     "resourceRequirements" : [
-        { "type": "MEMORY", "value": "1024"},
-        { "type": "VCPU", "value": "1024" }
+        { "type": "MEMORY", "value": "2048"},
+        { "type": "VCPU", "value": "1" }
     ],
     "volumes": [
         {
@@ -56,6 +56,7 @@ resource "aws_batch_job_definition" "generate_batch_jd_uploader" {
         }
     ],
     "jobRoleArn": "${aws_iam_role.aws_batch_job_role_uploader.arn}",
+    "executionRoleArn": "${data.aws_iam_role.batch_ecs_execution_role.arn}",
     "environment": [
       {
         "name": "TOPIC", "value": "${var.prefix}-upload-error"
@@ -63,7 +64,7 @@ resource "aws_batch_job_definition" "generate_batch_jd_uploader" {
     ]
   }
   CONTAINER_PROPERTIES
-  platform_capabilities = ["EC2"]
+  platform_capabilities = ["FARGATE"]
   propagate_tags        = true
   retry_strategy {
     attempts = 3

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,11 @@ data "aws_efs_file_system" "aws_efs_generate" {
   creation_token = var.prefix
 }
 
+data "aws_iam_role" "batch_ecs_execution_role" {
+  name = "${var.prefix}-batch-ecs-execution-role"
+}
+
+
 data "aws_s3_bucket" "l2p_granules" {
   bucket = "${var.prefix}-l2p-granules"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.3"
+  default     = "0.1.4"
 }
 
 variable "aws_region" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "app_version" {
   type        = string
   description = "The application version number"
-  default     = "0.1.4"
+  default     = "0.1.7"
 }
 
 variable "aws_region" {

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -76,7 +76,7 @@ class Uploader:
         "aqua": "MODIS_A-JPL-L2P-v2019.0",
         "terra": "MODIS_T-JPL-L2P-v2019.0",
         "viirs": "VIIRS_NPP-JPL-L2P-v2016.2",
-        "jpss1": "JPSS1-JPL-L2P-v2016.2"
+        "jpss1": "VIIRS_JPSS1-JPL-L2P-v2024.0"
     }
     COMBINER_PREFIX = "combiner_file_lists_"
     PROCESSOR_PREFIX = "processor_timestamp_list_"

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -76,7 +76,7 @@ class Uploader:
         "aqua": "MODIS_A-JPL-L2P-v2019.0",
         "terra": "MODIS_T-JPL-L2P-v2019.0",
         "viirs": "VIIRS_NPP-JPL-L2P-v2016.2",
-        "jpss1": "JPSS1_NPP-JPL-L2P-v2016.2"
+        "jpss1": "JPSS1-JPL-L2P-v2016.2"
     }
     COMBINER_PREFIX = "combiner_file_lists_"
     PROCESSOR_PREFIX = "processor_timestamp_list_"

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -105,13 +105,7 @@ class Uploader:
         self.processing_type = processing_type
         self.dataset = dataset
         self.logger = logger
-        if venue == "ops":
-            self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
-        else:
-            if dataset == "viirs":
-                self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
-            else:
-                self.cumulus_topic = f"podaac-{venue}-cumulus-throttled-provider-input-sns"
+        self.cumulus_topic = f"podaac-{venue}-cumulus-provider-input-sns"
         self.cross_account = self.get_cross_account_id(prefix)
         self.processed = []
         self.provenance = []

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -65,9 +65,9 @@ class Uploader:
             "filename": "TS-JPL-L2P_GHRSST-SSTskin-VIIRS_NPP-T-v02.0-fv01.0",
         },
         "jpss1": {
-            "dirname0": "JPSS1_L2P_CORE_NETCDF",
+            "dirname0": "VIIRS_L2P_CORE_NETCDF",
             "dirname1": "JPSS1",
-            "filename": "TS-JPL-L2P_GHRSST-SSTskin-JPSS1_NPP-T-v02.0-fv01.0",
+            "filename": "TS-JPL-L2P_GHRSST-SSTskin-JPSS1-T-v02.0-fv01.0",
         }
     }
     VERSION = "1.4"
@@ -189,6 +189,8 @@ class Uploader:
                     self.logger.info(f"Located Day File: {day_file_nc}")
                 else:
                     missing_checksum.append(day_file_nc)
+            else:
+                self.logger.error(f'day_file_nc: {day_file_nc} does not exist or is not a file.')
             # Check for night file
             night_file = file.replace('-T-', '-N-')
             night_file_nc = l2p_dir.joinpath(f"{night_file}.nc")

--- a/uploader/Uploader.py
+++ b/uploader/Uploader.py
@@ -63,6 +63,11 @@ class Uploader:
             "dirname0": "VIIRS_L2P_CORE_NETCDF",
             "dirname1": "VIIRS",
             "filename": "TS-JPL-L2P_GHRSST-SSTskin-VIIRS_NPP-T-v02.0-fv01.0",
+        },
+        "jpss1": {
+            "dirname0": "JPSS1_L2P_CORE_NETCDF",
+            "dirname1": "JPSS1",
+            "filename": "TS-JPL-L2P_GHRSST-SSTskin-JPSS1_NPP-T-v02.0-fv01.0",
         }
     }
     VERSION = "1.4"
@@ -70,7 +75,8 @@ class Uploader:
     COLLECTION = {
         "aqua": "MODIS_A-JPL-L2P-v2019.0",
         "terra": "MODIS_T-JPL-L2P-v2019.0",
-        "viirs": "VIIRS_NPP-JPL-L2P-v2016.2"
+        "viirs": "VIIRS_NPP-JPL-L2P-v2016.2",
+        "jpss1": "JPSS1_NPP-JPL-L2P-v2016.2"
     }
     COMBINER_PREFIX = "combiner_file_lists_"
     PROCESSOR_PREFIX = "processor_timestamp_list_"

--- a/uploader/run_uploader.py
+++ b/uploader/run_uploader.py
@@ -44,6 +44,8 @@ def run_uploader():
         ds = "MODIS Aqua"
     elif dataset == "terra":
         ds = "MODIS Terra"
+    elif dataset == "jpss1":
+        ds = "JPSS1"
     else:
         ds = "VIIRS"
     logger.info(f"Job identifier: {os.environ.get('AWS_BATCH_JOB_ID')}")


### PR DESCRIPTION
## [0.1.7]

### Description

We are migrating the managed EC2 AWS Batch Compute Environments to Fargate to prevent the need for AMI updates and to hopefully resolve the issue we are seeing with the ECS agent on EC2 instances.

Issues:

- https://github.com/podaac/generate/issues/25
- https://jira.jpl.nasa.gov/browse/PODAAC-6941

Documentation on issue:

- https://wiki.jpl.nasa.gov/pages/viewpage.action?pageId=826914206#GenerateCloudFailures&Recovery-2025-07-05-2025-07-07P&Sfailures


### Overview of work done

- Generate: Adds Fargate compute resources for batch jobs
- Generate: Removes lifeycle 'create_before_destroy' for EC2 compute resources since this policy was preventing terraform from applying the changes
- P&S: Added source hash in terraform file so it can detect changes to the job config json file
- P&S: Set retires to 0 so it only runs once
- Downloader, Combiner, Processor, Uploader, License Returner: Updated job definition/resources for Fargate instead of EC2
- Error Handler: Update EventBridge rule to ignore P&S failures.


### Overview of verification done

- Tested in SIT on three OBPG L2 granules for MODIS Aqua to produce two L2P granules

### Overview of integration done

- Tested in UAT on 7/16/2025 - 7/17/2025 time range
- Analysis of results is located here: https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.7#GenerateCloudUATTestv0.1.7-RESULTS

### Test Summary

UAT JOB METRICS:

- Total Cost: ~$157.26
- Average Execution Time: 9.65 minutes
- Average Number of Granules: 33

OPS JOB METRICS:

- Total Cost: ~$237.41 (May include other services)
- Average Execution Time: 8.8 minutes
- Average Number of Granules: 37

NOTES:

- The main difference we saw between UAT and OPS is OPS is operating in a degraded state which requires occasional manual intervention. UAT seems to have produce the usual amount of files without errors and therefore producing more granules that OPS. 
- We did see a difference in the number and average execution time of granules between UAT and OPS. This could be due to the Fargate platform which has typically had slightly longer execution times than EC2. Despite this, it seems that Generate will execute hourly on Fargate and still produce the same number of granules.